### PR TITLE
Small dockerfile fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM debian@sha256:37096792055ed86f0fc67a80bd67295a475557ad1136a76be04213b6b672d
 
 #Install Prerequisits
 RUN dpkg --add-architecture armhf \
-&&  apt update -y \
-&&  apt upgrade -y \
-&&  apt install git build-essential cmake python3 curl -y \
-&&  apt install gcc-arm-linux-gnueabihf libc6:armhf libncurses5:armhf libstdc++6:armhf -y
+&&  apt-get update -y \
+&&  apt-get upgrade -y \
+&&  apt-get install --no-install-recommends -y git build-essential cmake python3 curl gcc-arm-linux-gnueabihf libc6:armhf libncurses5:armhf libstdc++6:armhf \
+&&  rm -rf /var/lib/apt/lists/*
 
 #Install Box86
 RUN git clone https://github.com/ptitSeb/box86.git \
@@ -51,9 +51,10 @@ RUN mkdir -p /build/steamcmd \
 FROM debian@sha256:37096792055ed86f0fc67a80bd67295a475557ad1136a76be04213b6b672d442
 
 RUN  dpkg --add-architecture armhf \
-&&   apt update -y \
-&&   apt upgrade -y \
-&&   apt install libc6:armhf ca-certificates knockd bc -y
+&&   apt-get update -y \
+&&   apt-get upgrade -y \
+&&   apt-get --no-install-recommends install libc6:armhf ca-certificates knockd bc -y \
+&&   rm -rf /var/lib/apt/lists/*
 
 COPY --from=0 /build/ /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM debian@sha256:37096792055ed86f0fc67a80bd67295a475557ad1136a76be04213b6b672d
 RUN dpkg --add-architecture armhf \
 &&  apt-get update -y \
 &&  apt-get upgrade -y \
-&&  apt-get install --no-install-recommends -y git build-essential cmake python3 curl gcc-arm-linux-gnueabihf libc6:armhf libncurses5:armhf libstdc++6:armhf \
+&&  apt-get install -y git build-essential cmake python3 curl gcc-arm-linux-gnueabihf libc6:armhf libncurses5:armhf libstdc++6:armhf \
 &&  rm -rf /var/lib/apt/lists/*
 
 #Install Box86
@@ -46,7 +46,7 @@ FROM debian@sha256:37096792055ed86f0fc67a80bd67295a475557ad1136a76be04213b6b672d
 RUN  dpkg --add-architecture armhf \
 &&   apt-get update -y \
 &&   apt-get upgrade -y \
-&&   apt-get --no-install-recommends install libc6:armhf ca-certificates knockd bc -y \
+&&   apt-get install libc6:armhf ca-certificates knockd bc -y \
 &&   rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM arm64v8/debian:bullseye-slim
+# debian bullseye slim
+FROM debian@sha256:37096792055ed86f0fc67a80bd67295a475557ad1136a76be04213b6b672d442
 
 #Install Prerequisits
 RUN dpkg --add-architecture armhf \
@@ -47,7 +48,7 @@ RUN mkdir -p /build/steamcmd \
 
 
 
-FROM arm64v8/debian:bullseye-slim
+FROM debian@sha256:37096792055ed86f0fc67a80bd67295a475557ad1136a76be04213b6b672d442
 
 RUN  dpkg --add-architecture armhf \
 &&   apt update -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# debian bullseye slim
+# Debian bullseye slim base image
 FROM debian@sha256:37096792055ed86f0fc67a80bd67295a475557ad1136a76be04213b6b672d442 as builder
 
 #Install Prerequisits
@@ -40,7 +40,7 @@ RUN mkdir -p /build/steamcmd \
 &&  cd /build/steamcmd \
 &&  curl -sqL "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz" | tar zxvf -
 
-
+# Debian bullseye slim base image
 FROM debian@sha256:37096792055ed86f0fc67a80bd67295a475557ad1136a76be04213b6b672d442
 
 RUN  dpkg --add-architecture armhf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,13 +40,6 @@ RUN mkdir -p /build/steamcmd \
 &&  cd /build/steamcmd \
 &&  curl -sqL "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz" | tar zxvf -
 
-#Install BepInEx
-#RUN mkdir -p /build/BepInEx \
-#&&  cd /build/BepInEx \
-#&&  curl -sqL "https://valheim.plus/cdn/0.9.9/UnixServer.tar.gz" | tar zxvf - \
-#&&  rm ./BepInEx/plugins/ValheimPlus.dll
-
-
 
 FROM debian@sha256:37096792055ed86f0fc67a80bd67295a475557ad1136a76be04213b6b672d442
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # debian bullseye slim
-FROM debian@sha256:37096792055ed86f0fc67a80bd67295a475557ad1136a76be04213b6b672d442
+FROM debian@sha256:37096792055ed86f0fc67a80bd67295a475557ad1136a76be04213b6b672d442 as builder
 
 #Install Prerequisits
 RUN dpkg --add-architecture armhf \
@@ -56,7 +56,7 @@ RUN  dpkg --add-architecture armhf \
 &&   apt-get --no-install-recommends install libc6:armhf ca-certificates knockd bc -y \
 &&   rm -rf /var/lib/apt/lists/*
 
-COPY --from=0 /build/ /
+COPY --from=builder /build/ /
 
 RUN mkdir -p    /scripts \
 				/usr/local/bin \
@@ -81,7 +81,7 @@ RUN mkdir -p    /scripts \
 
 
 # Install BepInEx, required library and scripts
-ADD ./add /scripts/
+COPY ./add /scripts/
 RUN chmod +x /scripts/valheim.sh
 
 # Setting Environmental Variables
@@ -96,4 +96,4 @@ ENV SERVER_NAME=Raspiheim \
 
 EXPOSE 2456/udp 2457/udp
 
-ENTRYPOINT /scripts/valheim.sh
+ENTRYPOINT ["/scripts/valheim.sh"]


### PR DESCRIPTION
Hey! Thanks for uploading this to Github. I quickly went over your dockerfile and have a few small suggestions. Nothing major, maybe once I have more time I'll be able to contribute more meaningfully.

### Changes
- It's good practice to use `apt-get` instead of `apt` in Dockerfiles. I believe this is due to the fact that `apt-get`'s interface is stable
- I've removed the tag and sha-pinned both base image references in the dockerfile. this is to ensure that the base images do not unexpectedly change, which could break the image build
- I removed the commented BepInEx. it's in the git history now so I figured this was safe to remove
- ~~I added `--no-install-recommends` to all `apt-get install` calls so only the packages requested are installed~~
- I removed the `apt` lists after installing, as they're wasted space in the image
#### Suggested by Hadolint
- I named the first stage build "builder"
- I changed the `ADD` command to `COPY`
- I used JSON notation for the `ENTRYPOINT` directive